### PR TITLE
Changes https in base_url to http

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-REACT_APP_BASEURL = https://pocketramirorails2-env.ejk9ccddbs.us-west-1.elasticbeanstalk.com
+REACT_APP_BASEURL = http://pocketramirorails2-env.ejk9ccddbs.us-west-1.elasticbeanstalk.com


### PR DESCRIPTION
Pull Request Template

# Description
This changes the base url from https to http. Currently the fetch calls don't work, but the app has now been deployed on AWS via https://master.d2ybnzra4ei56p.amplifyapp.com/tickets